### PR TITLE
social: accept url to mastodon profile

### DIFF
--- a/templates/macros/social.html
+++ b/templates/macros/social.html
@@ -2,7 +2,7 @@
 {% if config.generate_feed %}{% if config.extra.social.feed %}      <a href="{{ get_url(path="atom.xml") }}" target="_blank"><span class="svg rss" title="Rss"></span></a>{% endif %}{% endif %}
 
 {% if social_config.mail %}      <a href="mailto:{{ social_config.mail }}" target="_blank"><span class="svg mail" title="Mail"></span></a>{% endif %}
-{% if social_config.mastodon %}      <a href="https://mastodon.social/{{ social_config.mastodon }}/" target="_blank"><span class="svg mastodon" title="Mastodon"></span></a>{% endif %}
+{% if social_config.mastodon %}      <a href="{{ social_config.mastodon }}/" target="_blank"><span class="svg mastodon" title="Mastodon"></span></a>{% endif %}
 {% if social_config.element %}      <a href="https://{{ social_config.element }}/" target="_blank"><span class="svg element" title="Element"></span></a>{% endif %}
 {% if social_config.matrix %}      <a href="https://{{ social_config.matrix }}/" target="_blank"><span class="svg matrix" title="Matrix"></span></a>{% endif %}
 {% if social_config.twitter %}      <a href="https://twitter.com/{{ social_config.twitter }}/" target="_blank"><span class="svg twitter" title="Twitter"></span></a>{% endif %}


### PR DESCRIPTION
mastodon accounts can exist on many different servers besides
mastodon.social, so this should really just accept a url to some
profile.

e.g.:

  mastodon = "https://freeradical.zone/@foobar"