### PR TITLE
base: add options to set copyright start/end years

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -81,3 +81,6 @@ instagram = "your-user-name"
 pinterest = "your-user-name"
 twitch = "your-user-name"
 youtube = "your-channel-id"
+
+start_year = 2019  # optional, copyright start year
+# end_year = 2022  #optional, copyright end year, defaults to current year if unset

--- a/templates/base.html
+++ b/templates/base.html
@@ -120,7 +120,13 @@
   <hr>
   <center>
     <p>{{ social_macros::social_links(social_config=config.extra.social) }}</p>
-    {# Copyright #}<p>Copyright &copy; 2019-{{ now() | date(format="%Y") }} {{ config.title }}</p>
+
+    {# Copyright #}
+    {% set start_year=config.extra.start_year | default(value="") %}
+    {% if start_year %}{% set start_year=start_year ~ "-" %}{% endif %}
+    {% set end_year=config.extra.end_year | default(value=now() | date(format="%Y")) %}
+    <p>Copyright &copy; {{ start_year ~ end_year}} {{ config.title }}</p>
+
     <p>{% for i in config.extra.menu_footer %}<a href="{{ get_url(path=i.url, trailing_slash=i.slash) }}">{{ i.name }}</a> &nbsp; {% endfor %}</p>
     {# Optional footer credit #}
     {% if config.extra.footer_credit %}


### PR DESCRIPTION
start_year and end_year are both optional. If start_year is unset, then
it's omitted from what is generated, so it'll be something like
"Copyright (c) 2022". if end_year is unset, then it defaults to the
current year.

fixes #4