### PR TITLE
base: make generating seo-related tags optional

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -81,3 +81,5 @@ instagram = "your-user-name"
 pinterest = "your-user-name"
 twitch = "your-user-name"
 youtube = "your-channel-id"
+
+# seo = true  # enable or disable seo-related tags, defaults to true

--- a/templates/404.html
+++ b/templates/404.html
@@ -2,10 +2,13 @@
 
 {# Title #}
 {% block title %}<title>Sorry! Page not found.</title>{% endblock title %}
-{% block current_url %}
-<meta property="og:url" content="{{ get_url(path='/') }}">
-<meta name="twitter:url" content="{{ get_url(path='/') }}">
-{% endblock current_url %}
+
+{% if config.extra.seo | default(value=true) %}
+  {% block current_url %}
+  <meta property="og:url" content="{{ get_url(path='/') }}">
+  <meta name="twitter:url" content="{{ get_url(path='/') }}">
+  {% endblock current_url %}
+{% endif %}
 {# Page heading #}
 
 {% block content %}<div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,12 +11,16 @@
   {% block description %}
     {% if page.description %}
       <meta name="description" content="{{ page.description }}" />
+      {% if config.extra.seo | default(value=true) %}
       <meta name="twitter:description" content="{{ page.description }}">
       <meta property="og:description" content="{{ page.description }}">
+      {% endif %}
     {% else %}
       <meta name="description" content="{{ config.description }}" />
+      {% if config.extra.seo | default(value=true) %}
       <meta name="twitter:description" content="{{ config.description}}">
       <meta property="og:description" content="{{ config.description }}">
+      {% endif %}
     {% endif %}
   {% endblock description %}
 
@@ -47,53 +51,58 @@
   {% endif %}
   <link rel="canonical" href="{{ get_url(path="/") }}">
   {% if config.generate_feed %}<link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path="atom.xml") }}">{% endif %}
-  {% block ogp_head %}
 
-  {% if page.title %}
-    <meta property="og:title" content="{{ page.title }} | {{ config.title }}">
-    <meta name="twitter:title" content="{{ page.title }} | {{ config.title }}">
-  {% else %}
-    <meta property="og:title" content="{{ config.title }}">
-    <meta name="twitter:title" content="{{ config.title }}">
-  {% endif %}
+  {% if config.extra.seo | default(value=true) %}
+    {% block ogp_head %}
+      {% if page.title %}
+        <meta property="og:title" content="{{ page.title }} | {{ config.title }}">
+        <meta name="twitter:title" content="{{ page.title }} | {{ config.title }}">
+      {% else %}
+        <meta property="og:title" content="{{ config.title }}">
+        <meta name="twitter:title" content="{{ config.title }}">
+      {% endif %}
 
-  <meta property="og:site_name" content="{{ config.title }}">
-  <meta property="og:locale" content="en_US">
-  <meta property="og:type" content="website">
-  <meta property="og:updated_time" content="{{ now() }}">{% endblock ogp_head %}
+      <meta property="og:site_name" content="{{ config.title }}">
+      <meta property="og:locale" content="en_US">
+      <meta property="og:type" content="website">
+      <meta property="og:updated_time" content="{{ now() }}">
+    {% endblock ogp_head %}
 
-  {% block current_url %}<meta property="og:url" content="{{ current_url | safe }}">
-  <meta name="twitter:url" content="{{ current_url | safe }}">{% endblock current_url %}
+    {% block current_url %}
+      <meta property="og:url" content="{{ current_url | safe }}">
+      <meta name="twitter:url" content="{{ current_url | safe }}">
+    {% endblock current_url %}
 
-  {% if config.extra.social.twitter %}
-  <meta name="twitter:site" content="@{{ config.extra.twitter }}">
-  <meta name="twitter:creator" content="@{{ config.extra.twitter }}">
-  {% endif %}
-
-  {% if page.extra.thumbnail %}
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:image" content="{{ get_url(path=page.path ~ page.extra.thumbnail, trailing_slash=false) }}">
-    <meta property="og:image" content="{{ get_url(path=page.path ~ page.extra.thumbnail, trailing_slash=false) }}">
-  {% elif page.extra.static_thumbnail %}
-    {%if page.extra.static_thumbnail is matching("^http[s]?://") %}
-      <meta name="twitter:card" content="summary_large_image">
-      <meta name="twitter:image" content="{{ page.extra.static_thumbnail }}">
-      <meta property="og:image" content="{{ page.extra.static_thumbnail }}">
-    {% else %}
-      <meta name="twitter:card" content="summary_large_image">
-      <meta name="twitter:image" content="{{ get_url(path=page.extra.static_thumbnail, trailing_slash=false) }}">
-      <meta property="og:image" content="{{ get_url(path=page.extra.static_thumbnail, trailing_slash=false) }}">
+    {% if config.extra.social.twitter %}
+    <meta name="twitter:site" content="@{{ config.extra.twitter }}">
+    <meta name="twitter:creator" content="@{{ config.extra.twitter }}">
     {% endif %}
-  {% elif config.extra.default_og_image %}
+
+    {% if page.extra.thumbnail %}
       <meta name="twitter:card" content="summary_large_image">
-      <meta name="twitter:image" content="{{ get_url(path=config.extra.default_og_image, trailing_slash=false) }}">
-      <meta property="og:image" content="{{ get_url(path=config.extra.default_og_image, trailing_slash=false) }}">
-  {% elif config.extra.banner %}
-      <meta name="twitter:card" content="summary_large_image">
-      <meta name="twitter:image" content="{{ get_url(path=config.extra.banner, trailing_slash=false) }}">
-      <meta property="og:image" content="{{ get_url(path=config.extra.banner, trailing_slash=false) }}">
-  {% else %}
-      <meta name="twitter:card" content="summary">
+      <meta name="twitter:image" content="{{ get_url(path=page.path ~ page.extra.thumbnail, trailing_slash=false) }}">
+      <meta property="og:image" content="{{ get_url(path=page.path ~ page.extra.thumbnail, trailing_slash=false) }}">
+    {% elif page.extra.static_thumbnail %}
+      {%if page.extra.static_thumbnail is matching("^http[s]?://") %}
+        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:image" content="{{ page.extra.static_thumbnail }}">
+        <meta property="og:image" content="{{ page.extra.static_thumbnail }}">
+      {% else %}
+        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:image" content="{{ get_url(path=page.extra.static_thumbnail, trailing_slash=false) }}">
+        <meta property="og:image" content="{{ get_url(path=page.extra.static_thumbnail, trailing_slash=false) }}">
+      {% endif %}
+    {% elif config.extra.default_og_image %}
+        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:image" content="{{ get_url(path=config.extra.default_og_image, trailing_slash=false) }}">
+        <meta property="og:image" content="{{ get_url(path=config.extra.default_og_image, trailing_slash=false) }}">
+    {% elif config.extra.banner %}
+        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:image" content="{{ get_url(path=config.extra.banner, trailing_slash=false) }}">
+        <meta property="og:image" content="{{ get_url(path=config.extra.banner, trailing_slash=false) }}">
+    {% else %}
+        <meta name="twitter:card" content="summary">
+    {% endif %}
   {% endif %}
 
 {% block extra_head %}{% endblock extra_head %}


### PR DESCRIPTION
this adds a new config option `seo` that allows switching off adding
seo-related tags to the page. if this option is unset, it defaults to
'true', preserving the existing (before this patch) behavior of the
theme.

fixes #3