### PR TITLE
SEO Boost: Updated SVG icons to be 48x48

### DIFF
--- a/sass/include/_icons.scss
+++ b/sass/include/_icons.scss
@@ -93,8 +93,8 @@
   @if $icon-x {.x { background-image: icon(x, "%23888", 2, "none") }}
   @if $icon-youtube {.youtube { background-image: icon(youtube, "%23f00", 2, "none") }}
   .svg {
-    width: 1.5rem;
-    height: 1.5rem;
+    width: 48px;
+    height: 48px;
     display: inline-block;
     overflow: hidden;
     vertical-align: middle


### PR DESCRIPTION
Google Lighthouse reports one issue with SEO - the icons are too small to be mobile compatible.
This fix makes the icons a bit bigger to boost SEO.


![2022-05-08_18-43](https://user-images.githubusercontent.com/48108917/167318835-d4fe46c0-2c57-4de3-9f5c-45d89a10e3e0.png)

