### PR TITLE
Allowed HTML in menu names

### DIFF
--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -17,7 +17,7 @@
             "sizes": "192x192",
             "type": "image/png",
             "purpose": "maskable"
-        },
+        }
     ],
     "theme_color": "#ffffff",
     "background_color": "#ffffff",

--- a/templates/base.html
+++ b/templates/base.html
@@ -79,7 +79,7 @@
       {#- Copyright END #}
       <p>
         {%- for i in config.extra.menu_footer %}
-        <a href="{{ get_url(path=i.url, trailing_slash=i.slash) }}">{{ i.name }}</a> &nbsp;
+        <a href="{{ get_url(path=i.url, trailing_slash=i.slash) }}">{{ i.name | safe }}</a> &nbsp;
         {%- endfor %}
       </p>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -35,7 +35,7 @@
       <div>
         <ul>
           {%- for i in config.extra.menu %}
-          <li><h2><a href="{{ get_url(path=i.url, trailing_slash=i.slash) }}">{{ i.name }}</a></h2></li>
+          <li><h2><a href="{{ get_url(path=i.url, trailing_slash=i.slash) }}">{{ i.name | safe }}</a></h2></li>
           {%- endfor %}
         </ul>
       </div>


### PR DESCRIPTION
Allows for nicer looks:
![2022-05-14_09-53](https://user-images.githubusercontent.com/48108917/168428827-a8935106-e03c-45ec-82af-1198cc2b830b.png)
![2022-05-14_09-53_1](https://user-images.githubusercontent.com/48108917/168428828-2fa97f2d-f957-4709-bc28-8a1faf919619.png)



I also removed a trailing comma in one of your recent commits.
