### PR TITLE
Add automatic rel="me" to Mastodon social link

### DIFF
--- a/templates/macros/social.html
+++ b/templates/macros/social.html
@@ -13,7 +13,7 @@
           {%- endif -%}
           {% endif -%}
           {%- if social_config.mastodon -%}
-          <li><a href="{{ social_config.mastodon }}/" target="_blank" title="Mastodon"><i type="Button" class="svg mastodon" title="Mastodon"></i></a></li>{% endif -%}
+          <li><a href="{{ social_config.mastodon }}/" target="_blank" title="Mastodon" rel="me"><i type="Button" class="svg mastodon" title="Mastodon"></i></a></li>{% endif -%}
           {%- if social_config.element -%}
           <li><a href="https://{{ social_config.element }}/" target="_blank" title="Element"><i type="Button" class="svg element" title="Element"></i></a></li>{% endif -%}
           {%- if social_config.matrix -%}


### PR DESCRIPTION
## Description
According to the [official documentation](https://docs.joinmastodon.org/user/profile/#verification) this is the simplest way to verify an account on Mastodon instances.

## Motivation
This PR would enable automatic "check mark" on Mastodon without needing to extend/overwrite the macro template while using the Abridge Theme.