### PR TITLE
Use "safe" statement on social macro to avoid Mastodon URL formatting

### DIFF
--- a/templates/macros/social.html
+++ b/templates/macros/social.html
@@ -13,7 +13,7 @@
           {%- endif -%}
           {% endif -%}
           {%- if social_config.mastodon -%}
-          <li><a href="{{ social_config.mastodon }}/" target="_blank" title="Mastodon" rel="me"><i type="Button" class="svg mastodon" title="Mastodon"></i></a></li>{% endif -%}
+          <li><a href="{{ social_config.mastodon | safe }}/" target="_blank" title="Mastodon" rel="me"><i type="Button" class="svg mastodon" title="Mastodon"></i></a></li>{% endif -%}
           {%- if social_config.element -%}
           <li><a href="https://{{ social_config.element }}/" target="_blank" title="Element"><i type="Button" class="svg element" title="Element"></i></a></li>{% endif -%}
           {%- if social_config.matrix -%}


### PR DESCRIPTION
Without "safe" statement, an URL like `https://fosstodon.org/@sancas/` will be formatted as `https:&#x2F;&#x2F;fosstodon.org&#x2F;@sancas/` in the Social Macro.

This would still work as a link, but defeats the purpose of the #99 PR (Mastodon doesn't seem to recognize the over-formatted URL) 