### PR TITLE
Delete Mastodon's social link trailing slash

### DIFF
--- a/templates/macros/social.html
+++ b/templates/macros/social.html
@@ -13,7 +13,7 @@
           {%- endif -%}
           {% endif -%}
           {%- if social_config.mastodon -%}
-          <li><a href="{{ social_config.mastodon | safe }}/" target="_blank" title="Mastodon" rel="me"><i type="Button" class="svg mastodon" title="Mastodon"></i></a></li>{% endif -%}
+          <li><a href="{{ social_config.mastodon | safe }}" target="_blank" title="Mastodon" rel="me"><i type="Button" class="svg mastodon" title="Mastodon"></i></a></li>{% endif -%}
           {%- if social_config.element -%}
           <li><a href="https://{{ social_config.element }}/" target="_blank" title="Element"><i type="Button" class="svg element" title="Element"></i></a></li>{% endif -%}
           {%- if social_config.matrix -%}


### PR DESCRIPTION
Hi, it's me again (you are going to kill me :sweat_smile: )

I didn't realize that I tested it without the trailing slash, and I forgot to include that change in the #100 PR.

With this change is definitely going to work.

P.S: Loving this theme, thanks for your work! :heart: 