### PR TITLE
Replace hardcoded font family list in CSS vars with sass vars

### DIFF
--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -113,9 +113,12 @@ $icon-moon: false !default;// dark moon
 $icon-sun: false !default;// light sun
 // add an icon link to an html template like this:  <a href="#"><span class="svg home"></span></a>
 
+$font-main	: "Roboto", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Noto Sans", Helvetica, Arial, sans-serif                                                                                      	!default;
+$font-code	: ui-monospace, Menlo, Monaco, Consolas, "SF Mono", "Cascadia Mono", "Segoe UI Mono", "DejaVu Sans Mono", "Liberation Mono", "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Ubuntu Mono", "Source Code Pro", "Fira Mono", "Droid Sans Mono", "Courier New", Courier, monospace	!default;
+
 :root {
-  --ff: "Roboto", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Noto Sans", Helvetica, Arial, sans-serif;
-  --fm: ui-monospace, Menlo, Monaco, Consolas, "SF Mono", "Cascadia Mono", "Segoe UI Mono", "DejaVu Sans Mono", "Liberation Mono", "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Ubuntu Mono", "Source Code Pro", "Fira Mono", "Droid Sans Mono", "Courier New", Courier, monospace;
+  #{--ff}: $font-main;
+  #{--fm}: $font-code;
 
   // Spacings
   --s1: .5rem;


### PR DESCRIPTION
Following our conversation https://github.com/Jieiku/abridge/issues/17 (though note that the 3rd benefit will only materialize with more refactoring towards use/mixins)

Allows (in the future after all the use refactor is done) the user to
  - programmatically adjust the list (i.e., append a couple of fonts) instead of having to copy&paste the full list
  - directly override the list in the theme by changing the value on import
  - combine the previous two items (will only work when everything is a mixin otherwise the styles are inserted on import and are not affected by later variable overrides)

> or you can use interpolation in the property name so that Sass's special custom property parsing behavior (which is necessary for CSS compatibility) doesn't activate:
```sas
$font-family: "Font with Spaces and 33", serif
:root
  #{--font-family}: $font-family
```

_Originally posted by @eugenesvk in https://github.com/Jieiku/abridge/issues/17#issuecomment-1529401135_
            