### PR TITLE
Align search code vertically

### DIFF
--- a/templates/macros/head.html
+++ b/templates/macros/head.html
@@ -114,17 +114,17 @@
   {%- endif %}
 
   {%- if config.build_search_index %}
-  {%- if search_library == "tinysearch" %}
-  <script defer type="module" src="{{ get_url(path='tinysearch.js', trailing_slash=false, cachebust=true) | safe }}"{%- if config.extra.integrity | default(value=true) %} integrity="sha384-{{ get_hash(path='tinysearch.js', sha_type=384, base64=true) | safe }}"{%- endif %}></script>
-  {%- elif search_library == "stork" %}
-  <script defer type="module" src="{{ get_url(path='search_stork.min.js', trailing_slash=false, cachebust=true) | safe }}"{%- if config.extra.integrity | default(value=true) %} integrity="sha384-{{ get_hash(path='search_stork.min.js', sha_type=384, base64=true) | safe }}"{%- endif %}></script>
-  {%- else %}
-  <script defer src="{{ get_url(path='elasticlunr.min.js', trailing_slash=false, cachebust=true) | safe }}"{%- if config.extra.integrity | default(value=true) %} integrity="sha384-{{ get_hash(path='elasticlunr.min.js', sha_type=384, base64=true) | safe }}"{%- endif %}></script>
-  <script defer src="{{ get_url(path='search.js', trailing_slash=false, cachebust=true) | safe }}"{%- if config.extra.integrity | default(value=true) %} integrity="sha384-{{ get_hash(path='search.js', sha_type=384, base64=true) | safe }}"{%- endif %}></script>
+  {%-   if search_library == "tinysearch" %}
+  <script defer type="module" src="{{ get_url(path='tinysearch.js'          , trailing_slash=false, cachebust=true) | safe }}"{%- if config.extra.integrity | default(value=true) %} integrity="sha384-{{ get_hash(path='tinysearch.js'          , sha_type=384, base64=true) | safe }}"{%- endif %}></script>
+  {%- elif search_library == "stork"      %}
+  <script defer type="module" src="{{ get_url(path='search_stork.min.js'    , trailing_slash=false, cachebust=true) | safe }}"{%- if config.extra.integrity | default(value=true) %} integrity="sha384-{{ get_hash(path='search_stork.min.js'    , sha_type=384, base64=true) | safe }}"{%- endif %}></script>
+  {%- else                                %}
+  <script defer src="{{               get_url(path='elasticlunr.min.js'     , trailing_slash=false, cachebust=true) | safe }}"{%- if config.extra.integrity | default(value=true) %} integrity="sha384-{{ get_hash(path='elasticlunr.min.js'     , sha_type=384, base64=true) | safe }}"{%- endif %}></script>
+  <script defer src="{{               get_url(path='search.js'              , trailing_slash=false, cachebust=true) | safe }}"{%- if config.extra.integrity | default(value=true) %} integrity="sha384-{{ get_hash(path='search.js'              , sha_type=384, base64=true) | safe }}"{%- endif %}></script>
 
   {%- if lang != "en" %}
-  <script defer src="{{ get_url(path='lunr.stemmer.support.js', trailing_slash=false, cachebust=true) | safe }}"{%- if config.extra.integrity | default(value=true) %} integrity="sha384-{{ get_hash(path='lunr.stemmer.support.js', sha_type=384, base64=true) | safe }}"{%- endif %}></script>
-  <script defer src="{{ get_url(path='lunr.' ~ lang ~ '.js', trailing_slash=false, cachebust=true) | safe }}"{%- if config.extra.integrity | default(value=true) %} integrity="sha384-{{ get_hash(path='lunr.' ~ lang ~ '.js', sha_type=384, base64=true) | safe }}"{%- endif %}></script>
+  <script defer src="{{               get_url(path='lunr.stemmer.support.js', trailing_slash=false, cachebust=true) | safe }}"{%- if config.extra.integrity | default(value=true) %} integrity="sha384-{{ get_hash(path='lunr.stemmer.support.js', sha_type=384, base64=true) | safe }}"{%- endif %}></script>
+  <script defer src="{{               get_url(path='lunr.' ~ lang ~ '.js'   , trailing_slash=false, cachebust=true) | safe }}"{%- if config.extra.integrity | default(value=true) %} integrity="sha384-{{ get_hash(path='lunr.' ~ lang ~ '.js'   , sha_type=384, base64=true) | safe }}"{%- endif %}></script>
   {%- endif %}
 
   {%- endif %}


### PR DESCRIPTION
FYI I'd also update the search code like so to make it much easier to read since it's easier to spot the diff when same pieces are in the same places (not suggesting to redo this in the whole code as it's too manual of a process, but that's just what I did anyway when adjusting this piece)

<img width="1046" alt="table" src="https://user-images.githubusercontent.com/12956286/235727891-e37e19ca-e5e0-47be-ac39-0ddb1bbff311.png">
