### PR TITLE
Allow appending font-family with user input

### DIFF
--- a/sass/_font-extend-COPY-ME.sass
+++ b/sass/_font-extend-COPY-ME.sass
@@ -1,0 +1,16 @@
+// This abridge theme extension allows you to append custom fonts to font-family of the:
+  // main font 'html'                               ('--ff' theme css variable in '_document.scss')
+  // code font 'pre','code','kbd','samp','tt','var' ('--fm' theme css variable in '_code.scss'    )
+// copy this file to your 'sass' folder:
+  // either: remove the leading '_' and add 'font-extend-COPY-ME.css' to your 'stylesheets' in 'config.toml'
+  // or    : import it with '@use "_font-extend-COPY-ME"' in whatever existing sass file you already load
+$findFont-Main	: "Segoe UI"                    	// ← append custom MAIN font(s) AFTER this (full list @ '_variables.scss')
+$findFont-Code	: "Segoe UI Mono"               	// ← append custom CODE font(s) AFTER this
+$fontExt-Main 	: ("MAIN FONT 1", "MAIN FONT 2")	// list of  custom MAIN font(s) to append
+$fontExt-Code 	: ("CODE FONT 1", "CODE FONT 2")	// list of  custom CODE font(s) to append
+
+@use "../themes/abridge/sass/font-extend" with($findFont-Main:$findFont-Main, $findFont-Code:$findFont-Code,$fontExt-Main:$fontExt-Main,$fontExt-Code:$fontExt-Code)
+// check ↑ relative path if you copy this file to some other location
+
+:root
+  @include font-extend.font-root

--- a/sass/_font-extend.sass
+++ b/sass/_font-extend.sass
@@ -1,0 +1,21 @@
+@use "variables"    	as var
+@use "function/font"	as f
+
+$findFont-Main  	: "Segoe UI"                    	!default
+$findFont-Code  	: "Segoe UI Mono"               	!default
+$fontExt-Main   	: ("MAIN FONT 1", "MAIN FONT 2")	!default
+$fontExt-Code   	: ("CODE FONT 1", "CODE FONT 2")	!default
+$iFoundFont-Main	: index(var.$font     , $findFont-Main)
+$iFoundFont-Code	: index(var.$font-mono, $findFont-Code)
+@if $iFoundFont-Main
+  var.$font      : f.font-append(var.$font     , $fontExt-Main, $findFont-Main)
+@else
+  @debug "⚠ Failed to find font '#{$findFont-Main}' in the list of '#{var.$font}'"
+@if $iFoundFont-Code
+  var.$font-mono : f.font-append(var.$font-mono, $fontExt-Code, $findFont-Code)
+@else
+  @debug "⚠ Failed to find font '#{$findFont-Code}' in the list of '#{var.$font-mono}'"
+
+@mixin font-root
+  #{--ff}: var.$font
+  #{--fm}: var.$font-mono //code

--- a/sass/_imports.scss
+++ b/sass/_imports.scss
@@ -13,7 +13,7 @@
  */
 
 // Config
-@use "variables";
+@forward "variables" as var-*;
 
 // Includes - Sorted by importance/category (includes at top are needed most frequently)
 @use "include/document"; // html

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -118,7 +118,7 @@ $icon-sun: false !default;// light sun
 $font: "Roboto", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Noto Sans", Helvetica, Arial, sans-serif !default;
 $font-mono: ui-monospace, Menlo, Monaco, Consolas, "SF Mono", "Cascadia Mono", "Segoe UI Mono", "DejaVu Sans Mono", "Liberation Mono", "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Ubuntu Mono", "Source Code Pro", "Fira Mono", "Droid Sans Mono", "Courier New", Courier, monospace !default;
 
-:root {
+@mixin root {
   #{--ff}: $font;
   #{--fm}: $font-mono;//code
 

--- a/sass/abridge-auto.scss
+++ b/sass/abridge-auto.scss
@@ -1,8 +1,11 @@
 @use "imports";
-@use "variables";
 @use "syntax/syntax-abridge" as syntax;
 
-@if variables.$syntax {
+:root {
+  @include imports.var-root;
+}
+
+@if imports.$var-syntax {
   :root {
     @include syntax.dark;
   }

--- a/sass/abridge-dark.scss
+++ b/sass/abridge-dark.scss
@@ -1,8 +1,11 @@
 @use "imports";
-@use "variables";
 @use "syntax/syntax-abridge" as syntax;
 
-@if variables.$syntax {
+:root {
+  @include imports.var-root;
+}
+
+@if imports.$var-syntax {
   @include syntax.dark;
 }
 

--- a/sass/abridge-light.scss
+++ b/sass/abridge-light.scss
@@ -1,8 +1,11 @@
 @use "imports";
-@use "variables";
 @use "syntax/syntax-abridge" as syntax;
 
-@if variables.$syntax {
+:root {
+  @include imports.var-root;
+}
+
+@if imports.$var-syntax {
   @include syntax.light;
 }
 

--- a/sass/abridge.scss
+++ b/sass/abridge.scss
@@ -1,8 +1,11 @@
 @use "imports";
-@use "variables";
 @use "syntax/syntax-abridge" as syntax;
 
-@if variables.$syntax {
+:root {
+  @include imports.var-root;
+}
+
+@if imports.$var-syntax {
   :root:not(.light) {
     @include syntax.dark;
   }

--- a/sass/function/_font.sass
+++ b/sass/function/_font.sass
@@ -1,0 +1,19 @@
+@use "sass:meta"
+@use "sass:list"
+
+@function font-append($base, $ext, $font-sep)
+  $base-pre	: ()
+  $base-pos	: ()
+  $iFontSep : index($base, $font-sep)
+  @if not $iFontSep // didn't find the font separator, return
+    @debug "⚠ Failed to find '#{$font-sep}' in the list of '#{$base}'"
+    @return $base
+
+  @for $i from 1 through list.length($base)
+    $iEl: list.nth($base, $i)
+    @if $i <= $iFontSep
+      $base-pre: list.append($base-pre, $iEl, $separator:comma)
+    @else
+      $base-pos: list.append($base-pos, $iEl, $separator:comma)
+
+  @return list.join(list.join($base-pre, $ext), $base-pos)


### PR DESCRIPTION
This adds the font extension partial style that allows users to append their fonts to the default font-family styles and an example file. Didn't find anything in the docs re. extending Abridge, so documented the use this example file `_font-extend-COPY-ME.sass` that the user is supposed to copy to his main repo, but it still needs to be mentioned somewhere

(also fixed the ~octuplicate appearance of the variables' root rules)

this still duplicates the `--ff`/`--fm` rules (once in user generated css, another time in abridge theme's generated css, user css wins), but then the alternative is might be too tricky to be worth it (the imports are order-sensitive, you'd first need to import the font override and only then import the main theme since you can't `@use` import the main them after using some functions to override the variables; and then the user would also need to explicitly disable the import of the main `abridge.css` in config)