### PR TITLE
add paginator on post page

### DIFF
--- a/sass/include/_paginator.scss
+++ b/sass/include/_paginator.scss
@@ -1,0 +1,15 @@
+.pagination {
+	margin-top: 2rem;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+
+	.left {
+ 		flex: 50%;
+		text-align: left;
+  	}
+  	.right {
+ 		flex: 50%;
+		text-align: right;
+  	}
+}

--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -124,6 +124,20 @@
 <p><b><a href="#">Back to top</a></b></p>
 {%- endif %}
 {%- endif %}
+{% if page.lower or page.higher-%}
+	<div class="pagination">
+	{% if page.lower -%}
+		<a href="{{ page.lower.permalink | safe }}" class="left arrow">&#8592;  {{ page.lower.title | truncate(length=120)}}</a>
+	{% else %}
+		<div class="left arrow">&#8592</div>
+	{%- endif %}
+	{% if page.higher -%}
+		<a href="{{ page.higher.permalink | safe }}" class="right arrow"> {{ page.higher.title | truncate(length=120) }} &#8594;</a>
+	{% else %}
+		<div class="right arrow">&#8594;</div>
+	{%- endif %}
+	</div>
+{%- endif %}
 {%- endmacro footer %}
 
 


### PR DESCRIPTION
This change displays the last and next article at the bottom of a post, a paginator. This is a first working example. Let me know what you think. It can also wait.

https://github.com/wold5/abridge/blob/d6eb9dc3a586055c7d2a9e89878eaa853fa4a39c/templates/macros/macros.html#L121-L141

Its build after the paginator from tale-zola: [template here](https://github.com/aaranxu/tale-zola/blob/5108a4ae31352ecd3aa3d7ab8fc85038975f46a8/templates/page.html#L64-L73) and [css here](https://github.com/aaranxu/tale-zola/blob/main/sass/tale/_pagination.scss) (MIT license). 
Tale-zola's implementation uses absolute/relative CSS positioning, which overlap on smaller screensizes. After fiddling a bit with CSS, the simplest solution was a flexbox setup. The CSS animations were left out, and truncation was added for long posts. [It requires Zola 1.6.0 at minimum](https://github.com/aaranxu/tale-zola/pull/7).

Note tale-zola puts the 'top' link in between both pagelinks, which looks OK.

PS. required is the @import "include/pagination";