### PR TITLE
Simplify check for number of languages

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -66,11 +66,7 @@
           {%- if icon_adjust -%}<i type="reset" id="mode" class="js {{ icon_adjust }}"></i>{%- else -%}<i type="reset" id="mode" class="js mode">&#9728;</i>{%- endif -%}
           {%- endif -%}
           {%- endif -%}
-          {%- set language_count = 1 -%}
-          {%- for language_name, language in config.languages -%}
-          {%- set_global language_count = language_count + 1 -%}
-          {%- endfor -%}
-          {%- if language_count > 1 %}
+          {%- if config.languages | length > 0 %}
           <div class="dropdown" type="Button"> {%- if lang != config.default_language %}{{ trans(key="flag" | safe, lang=lang) }}{% else %}{{ config.extra.flag.en }}{% endif %}
             {%- if current_url %}
             <div class="dropdown-content">


### PR DESCRIPTION
Checks the length of `config.languages` directly instead of looping over them (before building language switcher).

Since `language_count` is not used anywhere else, this small change improves the simplicity and readability of the code.