### PR TITLE
link to the proper language feed

### DIFF
--- a/templates/macros/social.html
+++ b/templates/macros/social.html
@@ -1,7 +1,7 @@
 {%- macro social_links(config) %}
       <nav>
-          {%- if config.generate_feed -%}{%- if config.extra.feed -%}
-          <a href="{{ get_url(path=config.feed_filename, trailing_slash=false) | safe }}" target="_blank" title="Atom/RSS Feed"><i type="Button" class="svg rss" title="Atom/RSS Feed"></i></a>{% endif -%}{% endif -%}
+          {%- if config.generate_feed and config.extra.feed -%}
+          <a href="{{ get_url(path=config.feed_filename, trailing_slash=false, lang=lang) | safe }}" target="_blank" title="Atom/RSS Feed"><i type="Button" class="svg rss" title="Atom/RSS Feed"></i></a>{% endif -%}
           {%- if config.extra.mail -%}
           {%- if config.extra.mail_encode | default(value=true) -%}
           {%- set base64_email = config.extra.mail -%}


### PR DESCRIPTION
The atom/rss feed link icons at the bottom of the page were always redirecting to the same feed, regardless of the selected language.

With this change, the URL now becomes language-aware, ensuring that users are directed to the appropriate feed based on their chosen language.

Additionally, this commit simplifies the "if" logic by replacing the nested ifs with a more concise "and" condition, resulting in cleaner and more readable code.