### PR TITLE
Fix: Always load `nojs.css` irrespective of `build_search_index` setting

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -27,9 +27,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   {{- macros_head::security(config=config) }}
   {{- macros_head::favicons(config=config) }}
-  {%- if config.build_search_index %}
   <noscript><link rel="stylesheet" href="{{ get_url(path='nojs.css', trailing_slash=false) | safe }}" /></noscript>
-  {%- endif %}
 </head>
 <body>
 {%- block header %}


### PR DESCRIPTION
Currently, the `nojs.css` file is only loaded when `config.build_search_index` returns false. This file is responsible for hiding JavaScript elements when JavaScript is disabled in the user's browser.

In practice, this means JavaScript elements like the theme switcher button or the encoded email (in the socials section) are mistakenly visible when JavaScript is disabled, as long as `build_search_index` is not set to `true` in `config.toml`. This is contrary to the expected behavior where these elements should be hidden when JavaScript is disabled, irrespective of the `build_search_index` setting.

This PR fixes this issue by removing the conditional, effectively ensuring that the `nojs.css` file is always loaded when JavaScript is disabled. This change aligns the behavior with the intended functionality of hiding specific JavaScript-dependent elements when JavaScript is not enabled.