### PR TITLE
Remove unnecessary <b> tag

### DIFF
--- a/sass/abridge.scss
+++ b/sass/abridge.scss
@@ -1200,6 +1200,10 @@ $syntax: true !default;//syntax highlighting for code blocks
     ol {
       margin: 0;
     }
+    .scur {//series current page
+      font-weight: var(--fh);
+      color: var(--a1);
+    }
   }
   .sblock {
   @if $series {
@@ -1213,10 +1217,7 @@ $syntax: true !default;//syntax highlighting for code blocks
       margin-bottom: .2rem;
       color: var(--c4);
     }
-    .scur {//series current page
-      font-weight: var(--fh);
-      color: var(--a1);
-    }
+
   }
     ol,ul {
       font-size: 1em;

--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -15,7 +15,7 @@
 {%- set uglyurls = config.extra.uglyurls | default(value=false) -%}
 {%- if config.extra.offline %}{% set uglyurls = true %}{% endif %}
   {%- if inner.content == page.content %}
-      <li><a class="scur" href="{{ inner.permalink | safe }}{%- if uglyurls %}index.html{%- endif %}"><b>{{ inner.title }}</b></a></li>
+      <li><a class="scur" href="{{ inner.permalink | safe }}{%- if uglyurls %}index.html{%- endif %}">{{ inner.title }}</a></li>
     {% else %}
       <li><a href="{{ inner.permalink | safe }}{%- if uglyurls %}index.html{%- endif %}">{{ inner.title }}</a></li>
   {%- endif %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -64,7 +64,7 @@
         <ol>
         {%- for inner in tag.pages | sort(attribute="date") %}
           {%- if inner.content == page.content %}
-            <li><a class="b" href="{{ inner.permalink | safe }}{%- if uglyurls %}index.html{%- endif %}">{{ inner.title }}</a></li>
+            <li><a class="scur" href="{{ inner.permalink | safe }}{%- if uglyurls %}index.html{%- endif %}">{{ inner.title }}</a></li>
             {%- set_global current_section_index = loop.index0 %} {# Finds the current section, needed for pagination logic later #}
           {% else %}
             <li><a href="{{ inner.permalink | safe }}{%- if uglyurls %}index.html{%- endif %}">{{ inner.title }}</a></li>

--- a/templates/page.html
+++ b/templates/page.html
@@ -64,7 +64,7 @@
         <ol>
         {%- for inner in tag.pages | sort(attribute="date") %}
           {%- if inner.content == page.content %}
-            <li><a href="{{ inner.permalink | safe }}{%- if uglyurls %}index.html{%- endif %}"><b>{{ inner.title }}</b></a></li>
+            <li><a class="b" href="{{ inner.permalink | safe }}{%- if uglyurls %}index.html{%- endif %}">{{ inner.title }}</a></li>
             {%- set_global current_section_index = loop.index0 %} {# Finds the current section, needed for pagination logic later #}
           {% else %}
             <li><a href="{{ inner.permalink | safe }}{%- if uglyurls %}index.html{%- endif %}">{{ inner.title }}</a></li>


### PR DESCRIPTION
This change removes an unnecessary `<b>` tag within the series code.

Also, should the [`scur`](https://github.com/Jieiku/abridge/blob/4343b5799cdae7f75a0c4d639482dabfc2c5f318/sass/abridge.scss#L1216-L1219) tag be moved outside of the `.sblock`? Meaning that the series side bar and the in-place series block both have consistent styling for the current page element.

This would mean that this would be `scur`:
https://github.com/Jieiku/abridge/blob/4343b5799cdae7f75a0c4d639482dabfc2c5f318/templates/page.html#L67
