### PR TITLE
break long words in sidebar menu

### DIFF
--- a/sass/abridge.scss
+++ b/sass/abridge.scss
@@ -1197,6 +1197,7 @@ $syntax: true !default;//syntax highlighting for code blocks
     padding: .2rem 0 var(--s2) var(--s2);
     max-height: 100vh;
     overflow: auto;
+    overflow-wrap: break-word;
     a {
       color: var(--f1);
       &:hover {


### PR DESCRIPTION
Fixes long words overflowing out of the sidebar menu as used for the TOC, Recent, Series, etc.

Started with word-break, but that seems deprecated, and is really `word-break: normal` with `overflow-wrap: break-word`.

https://developer.mozilla.org/en-US/docs/Web/CSS/word-break
https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap