### PR TITLE
Fix bug in package_abridge.js

### DIFF
--- a/package_abridge.js
+++ b/package_abridge.js
@@ -36,7 +36,7 @@ const pwa_BASE_CACHE_FILES = data.extra.pwa_BASE_CACHE_FILES;
 
 // This is used to pass arguments to zola via npm, for example:
 // npm run abridge -- "--base-url https://abridge.pages.dev"
-const args = (' '+process.argv[2] || '');
+const args = process.argv[2] ? ' '+process.argv[2] : '';
 
 async function execWrapper(cmd) {
   const { stdout, stderr } = await execPromise(cmd);


### PR DESCRIPTION
There was a bug in the expression for the args in the abridge npm (`package_abridge.js`) script, which was causing the variable to be undefined.

Due to the string expression always containing `' '`, it would always evaluate to true, resulting in undefined behavior. I have fixed it by using a ternary operator to correctly evaluate if it is true.

This created errors like this:
```bash
> abridge-bundle@2.0.0 abridge /.../abridge
> node -e "if ( require('fs').existsSync('./themes/abridge/package_abridge.js')) {require('fs').copyFileSync('./themes/abridge/package_abridge.js', './package_abridge.js')}" && node package_abridge.js

args:  undefined, process.argv: /usr/bin/node-20,/.../abridge/package_abridge.js
Zola Build to generate files for minification:
node:internal/errors:984
  const err = new Error(message);
              ^

Error: Command failed: zola build undefined
error: unexpected argument 'undefined' found

Usage: zola build [OPTIONS]

For more information, try '--help'.

    at genericNodeError (node:internal/errors:984:15)
    at wrappedFn (node:internal/errors:538:14)
    at ChildProcess.exithandler (node:child_process:422:12)
    at ChildProcess.emit (node:events:518:28)
    at maybeClose (node:internal/child_process:1105:16)
    at Socket.<anonymous> (node:internal/child_process:457:11)
    at Socket.emit (node:events:518:28)
    at Pipe.<anonymous> (node:net:337:12) {
  code: 2,
  killed: false,
  signal: null,
  cmd: 'zola build undefined',
  stdout: '',
  stderr: "error: unexpected argument 'undefined' found\n" +
    '\n' +
    'Usage: zola build [OPTIONS]\n' +
    '\n' +
    "For more information, try '--help'.\n"
}

Node.js v20.12.2
 ELIFECYCLE  Command failed with exit code 1.
```