### PR TITLE
Bump replace-in-file

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "fast-toml": "^0.5.4",
     "jsonminify": "^0.4.2",
     "pagefind": "^1.1.0",
-    "replace-in-file": "^7.0.1",
+    "replace-in-file": "^8.1.0",
     "uglify-js": "^3.17.4"
   }
 }

--- a/package_abridge.js
+++ b/package_abridge.js
@@ -7,15 +7,6 @@ const util  = require("util");
 const { exec } = require("child_process");
 const execPromise = util.promisify(exec);
 
-let replaceInFileSync;
-
-(async () => {
-  const replaceInFileModule = await import('replace-in-file');
-  replaceInFileSync = replaceInFileModule.replaceInFileSync;
-
-  // Your code that uses replaceInFileSync here
-})();
-
 if (!(fs.existsSync('config.toml'))) {
   throw new Error('ERROR: cannot find config.toml!');
 }

--- a/package_abridge.js
+++ b/package_abridge.js
@@ -3,10 +3,18 @@ const path = require("path");
 const TOML = require('fast-toml');
 const UglifyJS = require('uglify-js');
 const jsonminify = require("jsonminify");
-const { replaceInFileSync } = require('replace-in-file');
 const util  = require("util");
 const { exec } = require("child_process");
 const execPromise = util.promisify(exec);
+
+let replaceInFileSync;
+
+(async () => {
+  const replaceInFileModule = await import('replace-in-file');
+  replaceInFileSync = replaceInFileModule.replaceInFileSync;
+
+  // Your code that uses replaceInFileSync here
+})();
 
 if (!(fs.existsSync('config.toml'))) {
   throw new Error('ERROR: cannot find config.toml!');
@@ -49,6 +57,7 @@ async function execWrapper(cmd) {
 }
 
 async function abridge() {
+  const { replaceInFileSync } = await import('replace-in-file');
   if (offline === false) {
     if (typeof online_url !== 'undefined' && typeof online_indexformat !== 'undefined') {
       replaceInFileSync({files: 'config.toml', from: /base_url.*=.*/g, to: "base_url = \""+online_url+"\""});

--- a/package_abridge.js
+++ b/package_abridge.js
@@ -3,7 +3,7 @@ const path = require("path");
 const TOML = require('fast-toml');
 const UglifyJS = require('uglify-js');
 const jsonminify = require("jsonminify");
-const replace = require('replace-in-file');
+const { replaceInFileSync } = require('replace-in-file');
 const util  = require("util");
 const { exec } = require("child_process");
 const execPromise = util.promisify(exec);
@@ -51,13 +51,13 @@ async function execWrapper(cmd) {
 async function abridge() {
   if (offline === false) {
     if (typeof online_url !== 'undefined' && typeof online_indexformat !== 'undefined') {
-      replace.sync({files: 'config.toml', from: /base_url.*=.*/g, to: "base_url = \""+online_url+"\""});
-      replace.sync({files: 'config.toml', from: /index_format.*=.*/g, to: "index_format = \""+online_indexformat+"\""});
+      replaceInFileSync({files: 'config.toml', from: /base_url.*=.*/g, to: "base_url = \""+online_url+"\""});
+      replaceInFileSync({files: 'config.toml', from: /index_format.*=.*/g, to: "index_format = \""+online_indexformat+"\""});
     }
   } else if (offline === true) {
     if (typeof online_url !== 'undefined' && typeof online_indexformat !== 'undefined') {
-      replace.sync({files: 'config.toml', from: /base_url.*=.*/g, to: "base_url = \""+__dirname+"\/public\""});
-      replace.sync({files: 'config.toml', from: /index_format.*=.*/g, to: "index_format = \"elasticlunr_javascript\""});
+      replaceInFileSync({files: 'config.toml', from: /base_url.*=.*/g, to: "base_url = \""+__dirname+"\/public\""});
+      replaceInFileSync({files: 'config.toml', from: /index_format.*=.*/g, to: "index_format = \"elasticlunr_javascript\""});
     } else {
       throw new Error('ERROR: offline = true requires that online_url and online_indexformat are set in config.toml, so that the base_url and index_format can be restored if offline is later set to false.');
     }
@@ -87,20 +87,20 @@ async function abridge() {
 
   if (search_library === 'elasticlunr') {
     if (fs.existsSync('content/static/stork_toml.md')) {
-      replace.sync({files: 'content/static/stork_toml.md', from: /draft.*=.*/g, to: "draft = true"});
+      replaceInFileSync({files: 'content/static/stork_toml.md', from: /draft.*=.*/g, to: "draft = true"});
     }
     if (fs.existsSync('content/static/tinysearch_json.md')) {
-      replace.sync({files: 'content/static/tinysearch_json.md', from: /draft.*=.*/g, to: "draft = true"});
+      replaceInFileSync({files: 'content/static/tinysearch_json.md', from: /draft.*=.*/g, to: "draft = true"});
     }
   } else if (search_library === 'tinysearch') {
     if (!fs.existsSync('content/static/tinysearch_json.md')) {// 'content/static/tinysearch_json.md' file is missing, copy from abridge theme.
       fs.copyFileSync(bpath+'content/static/tinysearch_json.md', 'content/static/tinysearch_json.md',fs.constants.COPYFILE_EXCL);
     }
     if (fs.existsSync('content/static/stork_toml.md')) {
-      replace.sync({files: 'content/static/stork_toml.md', from: /draft.*=.*/g, to: "draft = true"});
+      replaceInFileSync({files: 'content/static/stork_toml.md', from: /draft.*=.*/g, to: "draft = true"});
     }
     if (fs.existsSync('content/static/tinysearch_json.md')) {
-      replace.sync({files: 'content/static/tinysearch_json.md', from: /draft.*=.*/g, to: "draft = false"});
+      replaceInFileSync({files: 'content/static/tinysearch_json.md', from: /draft.*=.*/g, to: "draft = false"});
     }
     // zola build && mkdir -p tmp && tinysearch --optimize --path tmp public/data_tinysearch/index.html && rsync -avz tmp/*.wasm static/ && rm -rf tmp
   } else if (search_library === 'stork') {
@@ -109,18 +109,18 @@ async function abridge() {
       fs.copyFileSync(bpath+'content/static/stork_toml.md', 'content/static/stork_toml.md',fs.constants.COPYFILE_EXCL);
     }
     if (fs.existsSync('content/static/stork_toml.md')) {
-      replace.sync({files: 'content/static/stork_toml.md', from: /draft.*=.*/g, to: "draft = false"});
+      replaceInFileSync({files: 'content/static/stork_toml.md', from: /draft.*=.*/g, to: "draft = false"});
     }
     if (fs.existsSync('content/static/tinysearch_json.md')) {
-      replace.sync({files: 'content/static/tinysearch_json.md', from: /draft.*=.*/g, to: "draft = true"});
+      replaceInFileSync({files: 'content/static/tinysearch_json.md', from: /draft.*=.*/g, to: "draft = true"});
     }
     // zola build && stork build --input public/data_stork/index.html --output static/stork.st
   } else if (search_library === 'pagefind') {
     if (fs.existsSync('content/static/stork_toml.md')) {
-      replace.sync({files: 'content/static/stork_toml.md', from: /draft.*=.*/g, to: "draft = true"});
+      replaceInFileSync({files: 'content/static/stork_toml.md', from: /draft.*=.*/g, to: "draft = true"});
     }
     if (fs.existsSync('content/static/tinysearch_json.md')) {
-      replace.sync({files: 'content/static/tinysearch_json.md', from: /draft.*=.*/g, to: "draft = true"});
+      replaceInFileSync({files: 'content/static/tinysearch_json.md', from: /draft.*=.*/g, to: "draft = true"});
     }
 
     // Run the pagefind script to generate the index files.
@@ -140,14 +140,14 @@ async function abridge() {
         if (js_bundle) {
           sw_load_min = '.min.js?v=';
         }
-        replace.sync({files: 'static/js/sw_load.js', from: /sw.*v=.*/g, to: "sw"+sw_load_min+pwa_VER+"\","});
+        replaceInFileSync({files: 'static/js/sw_load.js', from: /sw.*v=.*/g, to: "sw"+sw_load_min+pwa_VER+"\","});
       }
       if (fs.existsSync('static/sw.js')) {
-        replace.sync({files: 'static/sw.js', from: /NORM_TTL.*=.*/g, to: "NORM_TTL = "+pwa_NORM_TTL+";"});
-        replace.sync({files: 'static/sw.js', from: /LONG_TTL.*=.*/g, to: "LONG_TTL = "+pwa_LONG_TTL+";"});
-        replace.sync({files: 'static/sw.js', from: /TTL_NORM.*=.*/g, to: "TTL_NORM = ["+pwa_TTL_NORM+"];"});
-        replace.sync({files: 'static/sw.js', from: /TTL_LONG.*=.*/g, to: "TTL_LONG = ["+pwa_TTL_LONG+"];"});
-        replace.sync({files: 'static/sw.js', from: /TTL_EXEMPT.*=.*/g, to: "TTL_EXEMPT = ["+pwa_TTL_EXEMPT+"];"});
+        replaceInFileSync({files: 'static/sw.js', from: /NORM_TTL.*=.*/g, to: "NORM_TTL = "+pwa_NORM_TTL+";"});
+        replaceInFileSync({files: 'static/sw.js', from: /LONG_TTL.*=.*/g, to: "LONG_TTL = "+pwa_LONG_TTL+";"});
+        replaceInFileSync({files: 'static/sw.js', from: /TTL_NORM.*=.*/g, to: "TTL_NORM = ["+pwa_TTL_NORM+"];"});
+        replaceInFileSync({files: 'static/sw.js', from: /TTL_LONG.*=.*/g, to: "TTL_LONG = ["+pwa_TTL_LONG+"];"});
+        replaceInFileSync({files: 'static/sw.js', from: /TTL_EXEMPT.*=.*/g, to: "TTL_EXEMPT = ["+pwa_TTL_EXEMPT+"];"});
       }
 
       if (pwa_cache_all === true) {
@@ -185,7 +185,7 @@ async function abridge() {
       }
 
       // update the BASE_CACHE_FILES variable in the sw.js service worker file
-      results = replace.sync({
+      results = replaceInFileSync({
         files: 'static/sw.js',
         from: /this\.BASE_CACHE_FILES =.*/g,
         to: cache,

--- a/static/js/searchChange.js
+++ b/static/js/searchChange.js
@@ -1,11 +1,10 @@
 const fs = require('fs');
 const path = require("path");
-const { replaceInFileSync } = require('replace-in-file');
-
 // Path for config.toml
 const configTomlPath = path.join(__dirname, "../../config.toml");
 
 async function main() {
+  const { replaceInFileSync } = await import('replace-in-file');
     // Process arguments to determine the search mode
     const args = process.argv.slice(2); // Remove the first two default arguments
 
@@ -14,11 +13,11 @@ async function main() {
         switch (args[0]) {
             case '--pagefind':
                 console.log('Pagefind search mode activated.');
-                await swapToPagefind();
+                await swapToPagefind(replaceInFileSync);
                 break;
             case '--elasticlunr':
                 console.log('Elasticlunr search mode activated.');
-                await swapToElasticlunr();
+                await swapToElasticlunr(replaceInFileSync);
                 break;
             default:
                 console.log('Unknown search mode. Please use --pagefind or --elasticlunr.');
@@ -30,7 +29,7 @@ async function main() {
 
 main();
 
-async function swapToPagefind() {
+async function swapToPagefind(replaceInFileSync) {
     // Edit the config.toml file
     replaceInFileSync({
         files: configTomlPath,
@@ -49,7 +48,7 @@ async function swapToPagefind() {
     });
 }
 
-async function swapToElasticlunr() {
+async function swapToElasticlunr(replaceInFileSync) {
     // Edit the config.toml file
     replaceInFileSync({
         files: configTomlPath,

--- a/static/js/searchChange.js
+++ b/static/js/searchChange.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require("path");
-const replace = require('replace-in-file');
+const { replaceInFileSync } = require('replace-in-file');
 
 // Path for config.toml
 const configTomlPath = path.join(__dirname, "../../config.toml");
@@ -32,17 +32,17 @@ main();
 
 async function swapToPagefind() {
     // Edit the config.toml file
-    replace.sync({
+    replaceInFileSync({
         files: configTomlPath,
         from: /search_library = ['|"]\w+['|"]/g,
         to: 'search_library = "pagefind"',
     });
-    replace.sync({
+    replaceInFileSync({
         files: configTomlPath,
         from: /online_indexformat = ['|"]\w+['|"]/g,
         to: 'online_indexformat = "fuse_json"',
     });
-    replace.sync({
+    replaceInFileSync({
         files: configTomlPath,
         from: /index_format = ['|"]\w+['|"]/g,
         to: 'index_format = "fuse_json"',
@@ -51,17 +51,17 @@ async function swapToPagefind() {
 
 async function swapToElasticlunr() {
     // Edit the config.toml file
-    replace.sync({
+    replaceInFileSync({
         files: configTomlPath,
         from: /search_library = ['|"]\w+['|"]/g,
         to: 'search_library = "elasticlunr"',
     });
-    replace.sync({
+    replaceInFileSync({
         files: configTomlPath,
         from: /online_indexformat = ['|"]\w+['|"]/g,
         to: 'online_indexformat = "elasticlunr_json"',
     });
-    replace.sync({
+    replaceInFileSync({
         files: configTomlPath,
         from: /index_format = ['|"]\w+['|"]/g,
         to: 'index_format = "elasticlunr_json"',


### PR DESCRIPTION
This just updates `replace-in-file` to latest major release (which gets rid of some deprecated dependency warnings) and fixes the code which was changed by this release.