### PR TITLE
Fix syntax highlighting

### DIFF
--- a/COPY-TO-ROOT-SASS/abridge.scss
+++ b/COPY-TO-ROOT-SASS/abridge.scss
@@ -193,6 +193,7 @@
   //$misc: false,
   //$grid: true,//Infinity Grid, column based layouts.
   //$syntax: true,//syntax highlighting for code blocks
+  // $coderoundhighlight: false,//round corners on highlighted code blocks
 );
 @use "extra";
 /******************************************************************************

--- a/content/overview-code-blocks.md
+++ b/content/overview-code-blocks.md
@@ -68,7 +68,7 @@ fn main() {
 ```
 
 ### Bash
-```bash
+```bash,hl_lines=5
 #!/bin/bash
 for d in /sys/kernel/iommu_groups/*/devices/*; do
   n=${d#*/iommu_groups/*}; n=${n%%/*}

--- a/sass/abridge.scss
+++ b/sass/abridge.scss
@@ -934,12 +934,28 @@ $syntax: true !default;//syntax highlighting for code blocks
       // Highlighted text
       color: var(--h1);
       mark {
-        display: block;
-        color: unset;
-        padding: 0;
-        background-color: var(--h0);
-        filter: brightness(var(--ha));
+        border-radius: unset;
       }
+      td:first-child {
+        mark {
+          border-top-left-radius: var(--br);
+          border-bottom-left-radius: var(--br);
+        }
+      }
+      td:last-child {
+        mark {
+          border-top-right-radius: var(--br);
+          border-bottom-right-radius: var(--br);
+        }
+      }
+    }
+    mark {
+      display: block;
+      color: unset;
+      padding: 0;
+      background-color: var(--h0);
+      filter: brightness(var(--ha));
+      border-radius: var(--br);
     }
     td, th, tr {
       padding: 0;

--- a/sass/abridge.scss
+++ b/sass/abridge.scss
@@ -223,6 +223,7 @@ $imgswap: true !default;//Image Swap on hover/click
 $misc: false !default;
 $grid: true !default;//Infinity Grid, column based layouts.
 $syntax: true !default;//syntax highlighting for code blocks
+$coderoundhighlight: false !default;//round corners on highlighted code blocks
 
 
 /******************************************************************************
@@ -933,20 +934,22 @@ $syntax: true !default;//syntax highlighting for code blocks
       margin: 0;
       // Highlighted text
       color: var(--h1);
-      mark {
-        border-radius: unset;
-      }
-      td:first-child {
+      @if $coderoundhighlight {
         mark {
-          border-top-left-radius: var(--br);
-          border-bottom-left-radius: var(--br);
+          border-radius: unset;
         }
+        td:first-child {
+          mark {
+            border-top-left-radius: var(--br);
+            border-bottom-left-radius: var(--br);
+          }
+        }
+        td:last-child {
+          mark {
+            border-top-right-radius: var(--br);
+            border-bottom-right-radius: var(--br);
+          }
       }
-      td:last-child {
-        mark {
-          border-top-right-radius: var(--br);
-          border-bottom-right-radius: var(--br);
-        }
       }
     }
     mark {
@@ -955,7 +958,9 @@ $syntax: true !default;//syntax highlighting for code blocks
       padding: 0;
       background-color: var(--h0);
       filter: brightness(var(--ha));
-      border-radius: var(--br);
+      @if $coderoundhighlight {
+        border-radius: var(--br);
+      }
     }
     td, th, tr {
       padding: 0;


### PR DESCRIPTION
Currently if you try and highlight a line without line numbers, you get this:
![image](https://github.com/user-attachments/assets/f1598734-e273-4a21-a710-c4e40c5395c6)

So, I have fixed the scss to make it work on both styles of code blocks, I have also added some css to make nice rounded corners.
![image](https://github.com/user-attachments/assets/bd65039e-13c2-45e2-a54c-d152da15b81b)

But this rounded corners css does kind of mess up how it looks - so I am happy if you want to get rid of it.
![image](https://github.com/user-attachments/assets/ae8a7ffc-664a-40a8-a0c5-ef63bf86d3bd)
