### PR TITLE
Allow external links in menu_footer

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -136,7 +136,9 @@
       {%- if config.extra.menu_footer %}
       <nav class="vpad">
         {%- for i in config.extra.menu_footer -%}
-        {%- if i.url != "sitemap.xml" %}
+        {%- if '://' in i.url %}
+        {%- set furl=i.url %}
+        {%- elif i.url != "sitemap.xml" %}
         {%- set furl=get_url(path=i.url, lang=lang, trailing_slash=i.slash) %}
         {%- else %}
         {%- set furl=get_url(path=i.url, trailing_slash=i.slash) %}


### PR DESCRIPTION
## Why

I wanted to be able to set an external url to in one of the `menu_footer` items

## How

If the `url` contains `://` then we leave it as is and determine it to be an external url e.g. `https://test.com`

## Going further

This can also be done for the `menu` items if need be, let me know if you want me to add it to the PR.