### PR TITLE
Chores  🧹

### DIFF
--- a/COPY-TO-ROOT-SASS/abridge.scss
+++ b/COPY-TO-ROOT-SASS/abridge.scss
@@ -193,7 +193,7 @@
   //$misc: false,
   //$grid: true,//Infinity Grid, column based layouts.
   //$syntax: true,//syntax highlighting for code blocks
-  // $coderoundhighlight: false,//round corners on highlighted code blocks
+  //$coderoundhighlight: false,//round corners on highlighted code blocks
 );
 @use "extra";
 /******************************************************************************

--- a/package_abridge.js
+++ b/package_abridge.js
@@ -520,7 +520,6 @@ async function sync() {
     );
     exit(1);
   }
-  console.log(packageVersionLocal, packageVersionSubmodule);
 
   const configToml = path.join(__dirname, "config.toml");
   const submoduleConfigToml = path.join(


### PR DESCRIPTION
- Remove a leading space in `abridge.scss` for code highlight rounded corners
- Remove a superfluous `console.log` in `package_abridge.js` for showing package versions 