### PR TITLE
Use display grid for code

### DIFF
--- a/sass/abridge.scss
+++ b/sass/abridge.scss
@@ -911,7 +911,7 @@ $coderoundhighlight: false !default;//round corners on highlighted code blocks
     -ms-overflow-style: scrollbar;
     white-space: pre;
     > code {
-      display: block;
+      display: grid;
       background: transparent;
     }
   }


### PR DESCRIPTION
I have no clue what I am doing here, but this seems to fix the issue I had https://github.com/Jieiku/abridge/issues/218
![image](https://github.com/user-attachments/assets/89d72b56-ae52-4761-9a30-4891ce94aedd)
Not entirely sure if it is related to this change, but as you can see in the picture sometimes the "copy" button icon is getting clipped now. This may just be an artifact from the firefox responsive design testing thing though.