### PR TITLE
add block delimiters to page header so it can be overridden

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -38,12 +38,15 @@
 
 {%- block content %}
     <article>
+
+    {%- block page_header %}
     {{- macros::title_post(page=page, config=config) }}
 
     {%- if config.extra.meta_post.position %}
     {%- if config.extra.meta_post.position == "top" or config.extra.meta_post.position == "both" %}
     {{- macros::meta_post(page=page, config=config) }}
     {%- endif %}{%- endif %}
+    {%- endblock page_header %}
 
     {# In Page Series Navigation #}
     {%- if config.extra.series | default(value=true) %}


### PR DESCRIPTION
I would like to override the article header matter (title, metadata) so that I can add prev/next navigation links using the `page_footer` macro at the top of the article as well as at the bottom. I believe this adds the necessary block delimiters so that I can do so.