### PR TITLE
Adjust blockdiv right padding in abridge.scss

### DIFF
--- a/sass/abridge.scss
+++ b/sass/abridge.scss
@@ -1221,7 +1221,7 @@ $coderoundhighlight: false !default;//round corners on highlighted code blocks
     border-top: 5px solid var(--a1);
     background-color: var(--c2);
     margin-top: var(--s2);
-    padding: .2rem 0 var(--s2) var(--s2);
+    padding: .2rem var(--s1) var(--s2) var(--s2);
     max-height: 100vh;
     overflow: auto;
     overflow-wrap: break-word;


### PR DESCRIPTION
For table of contents short enough to have no scrollbar, the text would touch the right end of the block, which makes the layout look like it is on the verge of text overflow. Changing the right padding from `0` to `0.5rem` (`--s1`) would give the text some breathing space.

### Before

<img width="291" height="495" alt="Screenshot From 2026-01-09 23-59-03" src="https://github.com/user-attachments/assets/423a5e9f-a0f7-4744-bb77-7f3751b1b4d7" />



### After

<img width="291" height="495" alt="Screenshot From 2026-01-09 23-59-46" src="https://github.com/user-attachments/assets/a9476fee-8d6b-41ef-b9d2-a8b979b5d153" />
